### PR TITLE
Add methods and visibility

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -8,24 +8,39 @@ pub struct Entity {
     pub entity_type: EntityType,
     pub name: String,
     pub fields: Vec<Entity>,
+    pub visibility: Visibility,
 }
 
 impl Entity {
-    pub fn new(entity_type: EntityType, name: &str, fields: Vec<Entity>) -> Self {
+    pub fn new(entity_type: EntityType, name: &str, fields: Vec<Entity>, visibility: Visibility) -> Self {
         Entity {
             entity_type,
             name: name.to_string(),
             fields,
+            visibility,
         }
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Visibility {
+    Public,
+    Private,
+}
+
 impl PlantUml for Entity {
     fn render(&self) -> String {
+        let visibility = match self.visibility {
+            Visibility::Public => "+",
+            Visibility::Private => "-",
+        };
         let prefix = match self.entity_type {
-            EntityType::Struct => format!("class \"{}\" {{\n", self.name),
-            EntityType::Enum => format!("enum \"{}\" {{\n", self.name),
-            EntityType::Field(ref name) => format!("    + {}: {}\n", name, self.name),
+            EntityType::Struct =>
+                format!("class \"{}\" {{\n", self.name),
+            EntityType::Enum =>
+                format!("enum \"{}\" {{\n", self.name),
+            EntityType::Field(ref name) =>
+                format!("    {visibility} {}: {}\n", name, self.name),
             EntityType::Method(ref name) => {
                 let parameters: Vec<String> = self.fields.iter()
                     .filter_map(|field| {
@@ -37,7 +52,7 @@ impl PlantUml for Entity {
                     })
                     .collect();
                 let parameters_str = parameters.join(", ");
-                format!("    + {}({})\n", name, parameters_str)
+                format!("    {visibility} {}({})\n", name, parameters_str)
             },
 
             _ => {"".to_string()}

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,6 +26,21 @@ impl PlantUml for Entity {
             EntityType::Struct => format!("class \"{}\" {{\n", self.name),
             EntityType::Enum => format!("enum \"{}\" {{\n", self.name),
             EntityType::Field(ref name) => format!("    + {}: {}\n", name, self.name),
+            EntityType::Method(ref name) => {
+                let parameters: Vec<String> = self.fields.iter()
+                    .filter_map(|field| {
+                        if let EntityType::Parameter(ref param_type) = field.entity_type {
+                            Some(format!("{}: {}", param_type, field.name))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                let parameters_str = parameters.join(", ");
+                format!("    + {}({})\n", name, parameters_str)
+            },
+
+            _ => {"".to_string()}
         };
 
         let body: Vec<String> = self
@@ -34,6 +49,7 @@ impl PlantUml for Entity {
             .into_iter()
             .map(|field| match field.entity_type {
                 EntityType::Field(_) => field.render(),
+                EntityType::Method(_) => field.render(),
                 _ => "".to_string(),
             })
             .collect();
@@ -66,6 +82,8 @@ pub enum EntityType {
     Struct,
     Enum,
     Field(String),
+    Method(String),
+    Parameter(String),
 }
 
 fn make_dependencies(type_name: &str) -> HashSet<String> {


### PR DESCRIPTION
I've added the implemented methods of a struct to the PUML output.
The visibility of fields and methods is also respected.

The output of my test file:
````rust
pub struct MyStruct {
    pub public_field: i32,
    private_field: i32,
    second_struct: SecondStruct,
}

impl MyStruct {
    pub fn new(public_field: i32, private_field: i32, second_struct: SecondStruct) -> Self {
        MyStruct {
            public_field,
            private_field,
            second_struct
        }
    }

    pub fn get_private_field(&self) -> i32 {
        self.private_field
    }

    fn increment_private_field(&mut self) {
        self.private_field += 1;
    }
}

pub struct SecondStruct {
    pub second_public_field: i32,
    second_private_field: i32,
}

impl SecondStruct {
    pub fn get_second_private_field(&self) -> i32 {
        self.second_private_field
    }
}
```

results in this PUML output now:

```puml
@startuml

class "MyStruct" {
    + public_field: i32
    - private_field: i32
    - second_struct: SecondStruct
    + new(public_field: i32, private_field: i32, second_struct: SecondStruct)
    + get_private_field()
    - increment_private_field()
}

class "SecondStruct" {
    + second_public_field: i32
    - second_private_field: i32
    + get_second_private_field()
}
"MyStruct" <-- "SecondStruct"



@enduml
```

